### PR TITLE
Fix missing import statements in test_converter.py

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 from unittest.mock import Mock, patch, MagicMock
+from scapy.layers.inet import IP, TCP
 
 # Use the same try/except pattern for SCTP import
 try:


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/scimbe/PCAP2Packetdrill/pull/2?shareId=f4c6f79f-21a5-4519-a746-f123ab60842d).